### PR TITLE
Removed list of names on cards and delete member in modal

### DIFF
--- a/vite-project/package-lock.json
+++ b/vite-project/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-project",
       "version": "0.0.0",
       "dependencies": {
+        "@heroicons/react": "^2.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -824,6 +825,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.5.tgz",
+      "integrity": "sha512-FuzFN+BsHa+7OxbvAERtgBTNeZpUjgM/MIizfVkSCL2/edriN0Hx/DWRCR//aPYwO5QX/YlgLGXk+E3PcfZwjA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {

--- a/vite-project/package.json
+++ b/vite-project/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@heroicons/react": "^2.1.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/vite-project/src/App.jsx
+++ b/vite-project/src/App.jsx
@@ -1,9 +1,8 @@
 import { useState, useEffect } from "react";
 import "./App.css";
-import HomeScreen from "./screens/HomeScreen";
 import CreateGroup from "./components/Groups/CreateGroup";
 import DisplayGroupList from "./components/Groups/DisplayGroupList";
-import DashboardStyling from "./components/DashboardStyling";
+import DashboardStyling from "./components/UserDashboard/DashboardStyling";
 import Footer from "./components/Footer";
 import Nav from "./components/Nav";
 import DisplayExpensesList from "./components/Expenses/DisplayExpensesList";

--- a/vite-project/src/components/Groups/CreateGroup.jsx
+++ b/vite-project/src/components/Groups/CreateGroup.jsx
@@ -1,4 +1,4 @@
-import { React, useState } from "react";
+import { useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 export default function CreateGroup(props) {
@@ -21,6 +21,11 @@ export default function CreateGroup(props) {
   const handleEdit = (index) => {
     setEditIndex(index);
     setEditedMember(groupMembers[index]);
+  };
+
+  const handleDelete = (index) => {
+    const updatedMembers = groupMembers.filter((_, i) => i !== index);
+    setGroupMembers(updatedMembers);
   };
 
   const handleSave = (e) => {
@@ -144,7 +149,7 @@ export default function CreateGroup(props) {
                       />
                       <button
                         type="button"
-                        className="bg-pink text-button rounded text-sm mt-2 ml-4"
+                        className="bg-pink text-button rounded text-sm mt-2 ml-4 text-white"
                         onClick={handleSave}
                       >
                         Save
@@ -152,7 +157,7 @@ export default function CreateGroup(props) {
                     </div>
                   ) : (
                     <div>
-                      <span className="text-charcoal">{member}</span>
+                      <span className="text-charcoal mr-2 text-para">{member}</span>
                       <button
                         className="bg-transparent p-1"
                         onClick={() => handleEdit(index)}
@@ -163,7 +168,7 @@ export default function CreateGroup(props) {
                           viewBox="0 0 24 24"
                           strokeWidth={1.5}
                           stroke="currentColor"
-                          className="size-3 text-charcoal"
+                          className="size-4 text-charcoal"
                         >
                           <path
                             strokeLinecap="round"
@@ -171,6 +176,26 @@ export default function CreateGroup(props) {
                             d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
                           />
                         </svg>
+                      </button>
+                      <button
+                        className="bg-transparent p-1"
+                        onClick={() => handleDelete(index)}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          strokeWidth={1.5}
+                          stroke="currentColor"
+                          className="size-5 text-charcoal"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+                          />
+                        </svg>
+
                       </button>
                     </div>
                   )}

--- a/vite-project/src/components/Groups/DisplayGroup.jsx
+++ b/vite-project/src/components/Groups/DisplayGroup.jsx
@@ -4,7 +4,7 @@ export default function DisplayGroup(props) {
   const id = props.groupId;
  
   return (
-    <div className='border shadow rounded p-2 text-left relative bg-lightTeal min-w-72'>
+    <div className='border shadow rounded-xl p-3 text-left relative bg-lightTeal/40 min-w-72'>
       <h3 className='text-title mb-4 font-bold'>{props.groupName}</h3>
       <div className='flex flex-row absolute right-2 top-2'>
         <p className='pr-1'>{props.numGroupMembers}</p>
@@ -13,7 +13,7 @@ export default function DisplayGroup(props) {
         </svg>      
       </div>
       <p className='text-para mb-2'>{props.groupDescription}</p>
-      <div>
+      {/* <div>
       {props.groupMembers.map((member, index) => (
            <div key={index}>
                <p>{member}</p>
@@ -29,7 +29,7 @@ export default function DisplayGroup(props) {
                    </button>
             </div>
       ))}
-      </div>
+      </div> */}
       <p className='text-para'>$ Spent / {props.groupBudget}</p>
       <button className='bg-pink px-4 py-1 mt-6 text-button text-white'>Add Expense</button>
       <button  className='bg-transparent p-1 absolute bottom-1 right-10'>

--- a/vite-project/src/components/UserDashboard/DashboardStyling.jsx
+++ b/vite-project/src/components/UserDashboard/DashboardStyling.jsx
@@ -1,6 +1,7 @@
-import DashboardTop from "../assets/dashboard-top.png";
+import DashboardTop from "../../assets/dashboard-top.png";
 
 const DashboardStyling = () => {
+  
   return (
     <div className="relative">
       <img

--- a/vite-project/tailwind.config.js
+++ b/vite-project/tailwind.config.js
@@ -18,8 +18,8 @@ export default {
         sans: ["Open Sans", "sans-serif"]
       },
       fontSize: {
-        para: '1.25rem',   // 20px
-        button: '1.5rem',  // 24px
+        para: '1.125rem',   // 20px
+        button: '1.25rem',  // 20px
         title: '1.625rem', // 26px
         heading: '3rem',   // 48px
         hero: '4rem',      // 64px


### PR DESCRIPTION
Styled dashboard group card adding opacity and removed visibility of group member list on card (just commented out the code for now). Also, the delete functionality was added for a user in the group modal instead of on the card. You can now edit and delete a user within the modal.
<img width="1150" alt="Screenshot 2024-09-25 at 5 17 11 PM" src="https://github.com/user-attachments/assets/54ef1e3d-53f7-4b28-8655-33daf18be2d2">
<img width="645" alt="Screenshot 2024-09-25 at 5 17 56 PM" src="https://github.com/user-attachments/assets/c61e7dd9-0162-46e7-a95b-f050bce678d8">
